### PR TITLE
add tensor shape getter

### DIFF
--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -147,7 +147,9 @@ std::vector<T> Tensor::get_data() {
     return std::vector<T>(T_data, T_data + size);
 }
 
-
+std::vector<int64_t> Tensor::get_shape() {
+	return shape;
+}
 
 template<typename T>
 TF_DataType Tensor::deduce_type() {

--- a/src/Tensor.h
+++ b/src/Tensor.h
@@ -40,6 +40,8 @@ public:
     template<typename T>
     std::vector<T> get_data();
 
+	std::vector<int64_t> get_shape();
+
 private:
     TF_Tensor* val;
     TF_Output op;


### PR DESCRIPTION
Hi,

Since the tensor shape is private, it would be useful to have a getter for it. This way, we can know the input and output shapes of a loaded model.

Regards,

Carl